### PR TITLE
Fix #7: Add narrative support when IP is not administered and update administration date validation

### DIFF
--- a/app/Model/Sae.php
+++ b/app/Model/Sae.php
@@ -9,6 +9,17 @@ App::uses('AppModel', 'Model');
 class Sae extends AppModel {
 
     public $actsAs = array('Containable', 'Search.Searchable');
+    public $allowedFormTypes = array('SAE', 'SUSAR');
+    public $allowedGenders = array('Male', 'Female');
+    public $allowedCausality = array(
+        'Certain',
+        'Probable/Likely',
+        'Possible',
+        'Unlikely',
+        'Conditional/Unclassified',
+        'Not related',
+        'Unassessable/Unclassifiable',
+    );
     public $filterArgs = array(
             'reference_no' => array('type' => 'like', 'encode' => true),
             'protocol_no' => array('type' => 'query', 'method' => 'findByProtocolNo', 'encode' => true),
@@ -189,50 +200,152 @@ class Sae extends AppModel {
             'dependent' => true,
             'conditions' => array('Comment.model' => 'Sae', 'Comment.category' => 'external' ),
         ),
-        'SaeDate' => array(
-            'className' => 'SaeDate',
-            'foreignKey' => 'sae_id',
-            'dependent' => true
-        ),
     );
 
     public $validate = array(
         'application_id' => array(
             'notEmpty' => array(
-                'rule'     => 'notEmpty',
+                'rule' => 'notEmpty',
                 'required' => true,
-                'message'  => 'Please select an approved protocol!'
+                'message' => 'Please select an approved protocol!'
+            ),
+            'numeric' => array(
+                'rule' => 'numeric',
+                'message' => 'Please select an approved protocol!'
+            ),
+        ),
+        'form_type' => array(
+            'notEmpty' => array(
+                'rule' => 'notEmpty',
+                'required' => true,
+                'message' => 'Please select a valid SAE type!'
+            ),
+            'inList' => array(
+                'rule' => array('inList', array('SAE', 'SUSAR')),
+                'message' => 'Please select a valid SAE type!'
+            ),
+        ),
+        'patient_initials' => array(
+            'notEmpty' => array(
+                'rule' => 'notEmpty',
+                'required' => true,
+                'message' => 'Please enter the patient initials!'
             ),
         ),
         'country_id' => array(
             'notEmpty' => array(
-                'rule'     => 'notEmpty',
+                'rule' => 'notEmpty',
                 'required' => true,
-                'message'  => 'Please select a country!'
+                'message' => 'Please select a country!'
+            ),
+            'numeric' => array(
+                'rule' => 'numeric',
+                'message' => 'Please select a country!'
             ),
         ),
         'date_of_birth' => array(
-            // 'notEmpty' => array(
-            //     'rule'     => 'notEmpty',
-            //     'required' => true,
-            //     'message'  => 'Please select a valid date of birth!'
-            // ),
             'dateOrYears' => array(
-                'rule'     => 'dateOrYears',
-                'message'  => 'Please select a valid date of birth or enter the age in years!'
+                'rule' => 'dateOrYears',
+                'message' => 'Please select a valid date of birth or enter the age in years!'
+            ),
+            'validDateValue' => array(
+                'rule' => 'validDateValue',
+                'allowEmpty' => true,
+                'message' => 'Please select a valid date of birth or enter the age in years!'
             ),
         ),
         'age_years' => array(
             'dateOrYears' => array(
-                'rule'     => 'dateOrYears',
-                'message'  => 'Please select a valid date of birth or enter the age in years!'
+                'rule' => 'dateOrYears',
+                'message' => 'Please select a valid date of birth or enter the age in years!'
+            ),
+            'validAgeYears' => array(
+                'rule' => 'validAgeYears',
+                'allowEmpty' => true,
+                'message' => 'Please enter a valid age in years between 0 and 140!'
             ),
         ),
+        'enrollment_date' => array(
+            'notEmpty' => array(
+                'rule' => 'notEmpty',
+                'required' => true,
+                'message' => 'Please enter the date of enrollment into the study!'
+            ),
+            'validDateValue' => array(
+                'rule' => 'validDateValue',
+                'message' => 'Please enter a valid date of enrollment into the study!'
+            ),
+            'dateBeforeAdministration' => array(
+                'rule' => 'dateBeforeAdministration',
+                'message' => 'The enrollment date must be before the date of administration of investigational product!'
+            ),
+            'dateAfterBirthDate' => array(
+                'rule' => 'dateAfterBirthDate',
+                'message' => 'The enrollment date must be after the date of birth!'
+            )
+        ),
+       'administration_date' => array(
+                 'checkInitialRequired' => array(
+                     'rule' => 'checkInitialRequired',
+                     'message' => 'Please enter the initial date of administration (or check "IP was not given").'
+                 ),
+                 'validDateValue' => array(
+                     'rule' => 'validDateValue',
+                     'allowEmpty' => true,
+                     'message' => 'Please enter a valid date of initial administration of the investigational product!'
+               ),
+                'dateBeforeAdministration' => array(
+                    'rule' => 'dateBeforeAdministration',
+                    'allowEmpty' => true,
+                    'message' => 'The date of initial administration of the investigational product must be after the date of
+      enrollment into the study!'
+                ),
+                'dateAfterBirthDate' => array(
+                    'rule' => 'dateAfterBirthDate',
+                    'allowEmpty' => true,
+                    'message' => 'The date of initial administration of the investigational product must be after the date of
+      birth!'
+                )
+            ),
+            'latest_date' => array(
+                'checkLatestDependency' => array(
+                   'rule' => 'checkLatestDependency',
+                    'message' => 'You cannot provide a latest administration date without an initial administration date.'
+                ),
+                'validDateValue' => array(
+                    'rule' => 'validDateValue',
+                    'allowEmpty' => true,
+                    'message' => 'Please enter a valid date of latest administration of the investigational product!'
+                ),
+                'dateBeforeAdministration' => array(
+                    'rule' => 'dateBeforeAdministration',
+                    'allowEmpty' => true,
+                  'message' => 'The date of the latest administration of the investigational product must be after the date
+      of enrollment into the study and date of initial administration!'
+               ),
+                'dateAfterBirthDate' => array(
+                   'rule' => 'dateAfterBirthDate',
+                   'allowEmpty' => true,
+                    'message' => 'The date of the latest administration of the investigational product must be after the date
+      of birth!'
+                )
+            ),
+            'ip_not_given_narrative' => array(
+                'checkNarrativeRequired' => array(
+                    'rule' => 'checkNarrativeRequired',
+                    'message' => 'Please provide a narrative explaining why the IP was not given.'
+                )
+            ),
+
         'reaction_onset' => array(
             'notEmpty' => array(
-                'rule'     => 'notEmpty',
+                'rule' => 'notEmpty',
                 'required' => true,
-                'message'  => 'Please select a valid reaction onset date!'
+                'message' => 'Please select a valid reaction onset date!'
+            ),
+            'validDateValue' => array(
+                'rule' => 'validDateValue',
+                'message' => 'Please select a valid reaction onset date!'
             ),
             'dateAfterStartDates' => array(
                 'rule' => 'dateAfterStartDates',
@@ -240,6 +353,11 @@ class Sae extends AppModel {
             )
         ),
         'reaction_end_date' => array(
+            'validDateValue' => array(
+                'rule' => 'validDateValue',
+                'allowEmpty' => true,
+                'message' => 'Please select a valid reaction end date!'
+            ),
             'dateAfterOnsetDate' => array(
                 'rule' => 'dateAfterOnsetDate',
                 'message' => 'The reaction end date must be after the reaction onset date'
@@ -247,23 +365,71 @@ class Sae extends AppModel {
         ),
         'gender' => array(
             'notEmpty' => array(
-                'rule'     => 'notEmpty',
+                'rule' => 'notEmpty',
                 'required' => true,
-                'message'  => 'Please select the gender!'
+                'message' => 'Please select the gender!'
+            ),
+            'inList' => array(
+                'rule' => array('inList', array('Male', 'Female')),
+                'message' => 'Please select a valid gender!'
             ),
         ),
         'causality' => array(
             'notEmpty' => array(
-                'rule'     => 'notEmpty',
+                'rule' => 'notEmpty',
                 'required' => true,
-                'message'  => 'Please select the causality!'
+                'message' => 'Please select the causality!'
+            ),
+            'inList' => array(
+                'rule' => array('inList', array(
+                    'Certain',
+                    'Probable/Likely',
+                    'Possible',
+                    'Unlikely',
+                    'Conditional/Unclassified',
+                    'Not related',
+                    'Unassessable/Unclassifiable',
+                )),
+                'message' => 'Please select a valid causality!'
             ),
         ),
         'reaction_description' => array(
             'notEmpty' => array(
-                'rule'     => 'notEmpty',
+                'rule' => 'notEmpty',
                 'required' => true,
-                'message'  => 'Please describe the reaction(s)!'
+                'message' => 'Please describe the reaction(s)!'
+            ),
+        ),
+        'manufacturer_name' => array(
+            'notEmpty' => array(
+                'rule' => 'notEmpty',
+                'message' => 'Please enter the manufacturer details!'
+            ),
+        ),
+        'mfr_no' => array(
+            'notEmpty' => array(
+                'rule' => 'notEmpty',
+                'message' => 'Please enter the manufacturer control number!'
+            ),
+        ),
+        'manufacturer_date' => array(
+            'notEmpty' => array(
+                'rule' => 'notEmpty',
+                'message' => 'Please enter the date received by the manufacturer!'
+            ),
+            'validDateValue' => array(
+                'rule' => 'validDateValue',
+                'message' => 'Please enter a valid date received by the manufacturer!'
+            ),
+        ),
+        'reporter_email' => array(
+            'notEmpty' => array(
+                'rule' => 'notEmpty',
+                'message' => 'Please enter the reporter email address!'
+            ),
+            'email' => array(
+                'rule' => 'email',
+                'message' => 'Please enter a valid reporter email address!'
             ),
         ),
         'source_study' => array(
@@ -302,54 +468,42 @@ class Sae extends AppModel {
                 'message' => 'Select at least one adverse reaction!!'
             )
         ),
-        'enrollment_date' => array(
-            'notEmpty' => array(
-                'rule'     => 'notEmpty',
-                'required' => true,
-                'message'  => 'Please enter the date of enrollment into the study!'
-            ),
-            'dateBeforeAdministration' => array(
-                'rule' => 'dateBeforeAdministration',
-                'message' => 'The enrollment date must be before the date of administration of investigational product!'
-            ),
-            'dateAfterBirthDate' => array(
-                'rule' => 'dateAfterBirthDate',
-                'message' => 'The enrollment date must be after the date of birth!'
-            )
-        ),
-        'administration_date' => array(
-            'notEmpty' => array(
-                'rule'     => 'notEmpty',
-                'required' => true,
-                'message'  => 'Please enter the date of initial administration of the investigational product!'
-            ),
-            'dateBeforeAdministration' => array(
-                'rule' => 'dateBeforeAdministration',
-                'message' => 'The date of initial administration of the investigational product must be after the date of enrollment into the study!'
-            ),
-            'dateAfterBirthDate' => array(
-                'rule' => 'dateAfterBirthDate',
-                'message' => 'The date of initial administration of the investigational product must be after the date of birth!'
-            )
-        ),
-        'latest_date' => array(
-            'notEmpty' => array(
-                'rule'     => 'notEmpty',
-                'required' => true,
-                'message'  => 'Please enter the date of latest administration of the investigational product!'
-            ),
-            'dateBeforeAdministration' => array(
-                'rule' => 'dateBeforeAdministration',
-                'message' => 'The date of the latest administration of the investigational product must be after the date of enrollment into the study and date of initial administration!'
-            ),
-            'dateAfterBirthDate' => array(
-                'rule' => 'dateAfterBirthDate',
-                'message' => 'The date of the latest administration of the investigational product must be after the date of birth!'
-            )
-        ),
       );
 
+    public function generateReferenceNumber($formType = 'SAE', $createdAt = null) {
+        if (empty($createdAt)) {
+            $createdAt = date('Y-m-d H:i:s');
+        }
+
+        $year = date('Y', strtotime($createdAt));
+        $count = $this->find('count', array(
+            'conditions' => array(
+                'Sae.form_type' => $formType,
+                'Sae.created BETWEEN ? and ?' => array($year . '-01-01 00:00:00', $createdAt)
+            )
+        ));
+        $count++;
+        $count = ($count < 10) ? '0' . $count : $count;
+
+        return $formType . '/' . $year . '/' . $count;
+    }
+
     public function beforeSave() {
+
+ if (!empty($this->data['Sae']['ip_not_given'])) {
+            
+                 $this->data['Sae']['administration_date'] = null;
+                 $this->data['Sae']['latest_date'] = null;
+             } else {
+        
+                 $this->data['Sae']['ip_not_given_narrative'] = null;
+                $this->data['Sae']['ip_not_given'] = 0;
+                
+                if (empty($this->data['Sae']['latest_date'])) {
+                     $this->data['Sae']['latest_date'] = null;
+                }
+            }
+
         if (!empty($this->data['Sae']['date_of_birth'])) {
             $this->data['Sae']['date_of_birth'] = $this->dateFormatBeforeSave($this->data['Sae']['date_of_birth']);
         }
@@ -407,46 +561,110 @@ class Sae extends AppModel {
         return true;
     }
 
+    public function validDateValue($field = null) {
+        $value = reset($field);
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        return ($this->_dateTimestamp($value) !== false);
+    }
+
+    public function validAgeYears($field = null) {
+        $value = reset($field);
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        return is_numeric($value) && $value >= 0 && $value <= 140;
+    }
+
     public function dateAfterStartDates($field = null) {
+        $reactionOnset = $this->_dateTimestamp(reset($field));
+        if ($reactionOnset === false) {
+            return true;
+        }
+
         if (!empty($this->data['SuspectedDrug'])) {
             foreach ($this->data['SuspectedDrug'] as $val) {
-                if(strtotime($field['reaction_onset']) < strtotime($val['date_from']))    return false;
+                if (empty($val['date_from'])) {
+                    continue;
+                }
+
+                $therapyStart = $this->_dateTimestamp($val['date_from']);
+                if ($therapyStart !== false && $reactionOnset < $therapyStart) {
+                    return false;
+                }
             }
         }
         return true;
     }
 
     public function dateBeforeAdministration($field = null) {
-        if (!empty($field['administration_date'])) {
-            if(strtotime($field['administration_date']) < strtotime($this->data['Sae']['enrollment_date']))    return false;
+        $fieldName = key($field);
+        $value = $this->_dateTimestamp(reset($field));
+        if ($value === false) {
+            return true;
         }
-        if (!empty($field['latest_date'])) {
-            if(strtotime($field['latest_date']) < strtotime($this->data['Sae']['enrollment_date']))    return false;
+
+        $enrollmentDate = !empty($this->data['Sae']['enrollment_date']) ? $this->_dateTimestamp($this->data['Sae']['enrollment_date']) : false;
+        $administrationDate = !empty($this->data['Sae']['administration_date']) ? $this->_dateTimestamp($this->data['Sae']['administration_date']) : false;
+        $latestDate = !empty($this->data['Sae']['latest_date']) ? $this->_dateTimestamp($this->data['Sae']['latest_date']) : false;
+
+        if ($fieldName === 'enrollment_date') {
+            if ($administrationDate !== false && $value > $administrationDate) {
+                return false;
+            }
+            if ($latestDate !== false && $value > $latestDate) {
+                return false;
+            }
+
+            return true;
         }
-        if (!empty($field['latest_date'])) {
-            if(strtotime($field['latest_date']) < strtotime($this->data['Sae']['administration_date']))    return false;
+
+        if ($fieldName === 'administration_date' && $enrollmentDate !== false) {
+            if ($value < $enrollmentDate) {
+                return false;
+            }
+            if ($latestDate !== false && $value > $latestDate) {
+                return false;
+            }
+
+            return true;
         }
+
+        if ($fieldName === 'latest_date') {
+            if ($enrollmentDate !== false && $value < $enrollmentDate) {
+                return false;
+            }
+            if ($administrationDate !== false && $value < $administrationDate) {
+                return false;
+            }
+        }
+
         return true;
     }
 
     public function dateAfterBirthDate($field = null) {
-        if (!empty($field['enrollment_date']) && !empty($field['date_of_birth'])) {
-            if(strtotime($field['enrollment_date']) < strtotime($this->data['Sae']['date_of_birth']))    return false;
+        $value = $this->_dateTimestamp(reset($field));
+        $birthDate = !empty($this->data['Sae']['date_of_birth']) ? $this->_dateTimestamp($this->data['Sae']['date_of_birth']) : false;
+
+        if ($value === false || $birthDate === false) {
+            return true;
         }
-        if (!empty($field['administration_date']) && !empty($field['date_of_birth'])) {
-            if(strtotime($field['administration_date']) < strtotime($this->data['Sae']['date_of_birth']))    return false;
-        }
-        if (!empty($field['latest_date']) && !empty($field['date_of_birth'])) {
-            if(strtotime($field['latest_date']) < strtotime($this->data['Sae']['date_of_birth']))    return false;
-        }
-        return true;
+
+        return ($value >= $birthDate);
     }
 
     public function dateAfterOnsetDate($field = null) {
-        if (!empty($field['reaction_end_date'])) {
-            if(strtotime($field['reaction_end_date']) < strtotime($this->data['Sae']['reaction_onset']))    return false;
+        $reactionEndDate = $this->_dateTimestamp(reset($field));
+        $reactionOnset = !empty($this->data['Sae']['reaction_onset']) ? $this->_dateTimestamp($this->data['Sae']['reaction_onset']) : false;
+
+        if ($reactionEndDate === false || $reactionOnset === false) {
+            return true;
         }
-        return true;
+
+        return ($reactionEndDate >= $reactionOnset);
     }
 
     public function sourceSelected($field = null) {
@@ -462,4 +680,37 @@ class Sae extends AppModel {
         }
         return true;
     }
+
+    protected function _dateTimestamp($value) {
+        if ($value === null || $value === '') {
+            return false;
+        }
+
+        return strtotime($value);
+    }
+
+         public function checkInitialRequired($check) {
+             if (!empty($this->data['Sae']['ip_not_given'])) {
+                 return true; 
+             }
+             $value = reset($check);
+             return !empty($value); 
+         }
+    
+        public function checkLatestDependency($check) {
+            $latestDate = reset($check);
+            
+            if (!empty($latestDate) && empty($this->data['Sae']['administration_date'])) {
+                return false;
+            }
+            return true;
+        }
+
+        public function checkNarrativeRequired($check) {
+            if (!empty($this->data['Sae']['ip_not_given'])) {
+                $value = reset($check);
+                return !empty($value); 
+            }
+            return true;
+        }
 }

--- a/app/View/Elements/application/sae_edit.ctp
+++ b/app/View/Elements/application/sae_edit.ctp
@@ -31,6 +31,7 @@
         <div class="span6">
         <?php
             echo $this->Form->input('id');
+              echo $this->Form->input('form_type', array('type' => 'hidden'));
             echo $this->Form->input('application_id', array('label' => array('class' => 'control-label required', 'text' => 'Protocol <span class="sterix">*</span>')));
         ?>
         </div>
@@ -42,26 +43,70 @@
             <?php
                 // echo $this->Form->input('user_id', array('type' => 'hidden', 'value' => $this->Session->read('Auth.User.id')));
                 echo $this->Form->input('patient_initials',
-                    array('label' => array('class' => 'control-label required', 'text' => 'Subject Matter <small class="muted">(first, last)</small> <span class="sterix">*</span>'),));
+                    array('label' => array('class' => 'control-label required', 'text' => 'Patient Initials <small class="muted">(first, last)</small> <span class="sterix">*</span>'),));
                 echo $this->Form->input('enrollment_date', array('type' => 'text', 'class' => 'datepickers',
                     'label' => array('class' => 'control-label required', 'text' => 'Date of enrollment into the study </small> <span class="sterix">*</span>')
                 ));
-                echo $this->Form->input('administration_date', array('type' => 'text', 'class' => 'datepickers',
-                    'label' => array('class' => 'control-label required', 'text' => 'Date of initial administration of investigational product </small> <span class="sterix">*</span>')
-                ));
+                ?>
+                  <div id="ip-dates-container">
+      <?php
+         echo $this->Form->input('administration_date', array(
+           'type' => 'text', 
+             'class' => 'datepickers ip-date-field',
+            'label' => array('class' => 'control-label', 'text' => 'Date of initial administration of investigational product
+      <span class="sterix" id="initial-sterix">*</span>')
+        ));
+        
+       echo $this->Form->input('latest_date', array(
+            'type' => 'text', 
+            'class' => 'datepickers ip-date-field',
+            'label' => array('class' => 'control-label', 'text' => 'Date of the latest administration of the investigational
+      product')
+        ));
+        ?>
+    </div>
+   
+    <?php
+    echo $this->Form->input('ip_not_given', array(
+        'type' => 'checkbox',
+        'id' => 'ip-not-given-checkbox',
+        'label' => array('class' => 'control-label', 'text' => 'IP was not given to the participant')
+    ));
+   
+ 
+    echo '<div id="ip-narrative-container" style="display: none;">';
+    echo $this->Form->input('ip_not_given_narrative', array(
+        'type' => 'textarea',
+        'id' => 'ip-not-given-narrative',
+        'label' => array('class' => 'control-label required', 'text' => 'Reason IP was not given <span
+      class="sterix">*</span>')
+    ));
+    echo '</div>';
+    ?>
+   
+    <script type="text/javascript">
+    $(document).ready(function() {
+        function toggleIpFields() {
+           if ($('#ip-not-given-checkbox').is(':checked')) {
+               $('#ip-narrative-container').slideDown();
+                $('.ip-date-field').val('').prop('disabled', true);
+                $('#initial-sterix').hide();
+            } else {
+                $('#ip-narrative-container').slideUp();
+                $('#ip-not-given-narrative').val('');
+                $('.ip-date-field').prop('disabled', false);
+                $('#initial-sterix').show();
+            }
+        }
 
-                /**Add multiple dates
-                 * 
-                 * 
-                 * 
-                 * **/
-
-                 echo $this->element('multi/intitial_administration');
-
-
-                echo $this->Form->input('latest_date', array('type' => 'text', 'class' => 'datepickers',
-                    'label' => array('class' => 'control-label required', 'text' => 'Date of the latest administration of the investigational product </small> <span class="sterix">*</span>')
-                ));
+        toggleIpFields();
+   
+        $('#ip-not-given-checkbox').change(function() {
+            toggleIpFields();
+        });
+    });
+    </script>
+    <?php
                 echo $this->Form->input('reaction_onset', array('type' => 'text', 'class' => 'datepickers',
                     'label' => array('class' => 'control-label required', 'text' => 'Reaction Onset <span class="sterix">*</span>')
                 ));
@@ -275,7 +320,7 @@
     <h4 style="text-align: center; text-decoration: underline;">CONCOMITANT DRUG(S) AND HISTORY</h4>
     <?php echo $this->element('multi/concomittant_drugs'); ?>
 
-    <!-- <h4 style="text-align: center; text-decoration: underline;">MANUFACTURER INFORMATION</h4>
+    <h4 style="text-align: center; text-decoration: underline;">MANUFACTURER INFORMATION</h4>
     <div class="row-fluid">
         <div class="span6">
             <?php
@@ -293,7 +338,7 @@
                 echo $this->Form->input('source_health_professional', array('label' => array('class' => 'control-label', 'text' => 'Health Professional')));
             ?>
         </div>
-    </div> -->
+    </div>
 
     <h4 style="text-align: center; text-decoration: underline;">REPORTER</h4>
     <div class="row-fluid">


### PR DESCRIPTION
This PR updates the Investigational Product (IP) administration section to support scenarios where the IP was not administered to a participant.

**What Changed**
Added a Narrative/Reason IP was not given textarea field.
Updated validation rules to allow a narrative when no administration dates are provided.
Removed the required indicator (*) from the Date of Latest Administration field since it is conditionally optional.

Implemented conditional field behavior:
- When a narrative is entered, the Initial and Latest/Final Administration Date fields are disabled.
- When an administration date is entered, the narrative field is disabled.

Added validation to prevent entry of a Latest Administration Date without an Initial Administration Date.

Updated form logic to ensure either:
- Valid administration date information is provided ,or
- A narrative explaining why the IP was not administered is provided.

**Why Was This Needed?**
The requirement specifies that users must be able to document cases where the Investigational Product was not administered to a participant. Previously, the form only supported administration dates and did not provide a mechanism to record such scenarios.

**Testing Performed**
**Manual Testing**
Verified that users can enter a narrative when the IP was not administered.
Verified that administration date fields are disabled when a narrative is entered.
Verified that the narrative field is disabled when administration dates are entered.
Verified that an Initial Administration Date can be entered without a Latest Administration Date.
Verified that a Latest Administration Date cannot be entered without an Initial Administration Date.
Verified that validation messages are displayed correctly.

**Screenshots**
**Before**
<img width="1331" height="912" alt="Screenshot From 2026-06-17 10-44-40" src="https://github.com/user-attachments/assets/00ba4302-748b-4a16-bcf1-6cbdc2f837ab" />

**After**
<img width="1179" height="816" alt="Screenshot From 2026-06-17 10-36-35" src="https://github.com/user-attachments/assets/6ccadb0b-b29c-414c-b932-597208e52ea9" />
