### PR TITLE
Fix #7: Feat(sae) implement IP not given workflow

### DIFF
--- a/app/Model/Sae.php
+++ b/app/Model/Sae.php
@@ -284,44 +284,59 @@ class Sae extends AppModel {
                 'message' => 'The enrollment date must be after the date of birth!'
             )
         ),
-        'administration_date' => array(
-            'notEmpty' => array(
-                'rule' => 'notEmpty',
-                'required' => true,
-                'message' => 'Please enter the date of initial administration of the investigational product!'
+       'administration_date' => array(
+                 'checkInitialRequired' => array(
+                     'rule' => 'checkInitialRequired',
+                     'message' => 'Please enter the initial date of administration (or check "IP was not given").'
+                 ),
+                 'validDateValue' => array(
+                     'rule' => 'validDateValue',
+                     'allowEmpty' => true,
+                     'message' => 'Please enter a valid date of initial administration of the investigational product!'
+               ),
+                'dateBeforeAdministration' => array(
+                    'rule' => 'dateBeforeAdministration',
+                    'allowEmpty' => true,
+                    'message' => 'The date of initial administration of the investigational product must be after the date of
+      enrollment into the study!'
+                ),
+                'dateAfterBirthDate' => array(
+                    'rule' => 'dateAfterBirthDate',
+                    'allowEmpty' => true,
+                    'message' => 'The date of initial administration of the investigational product must be after the date of
+      birth!'
+                )
             ),
-            'validDateValue' => array(
-                'rule' => 'validDateValue',
-                'message' => 'Please enter a valid date of initial administration of the investigational product!'
+            'latest_date' => array(
+                'checkLatestDependency' => array(
+                   'rule' => 'checkLatestDependency',
+                    'message' => 'You cannot provide a latest administration date without an initial administration date.'
+                ),
+                'validDateValue' => array(
+                    'rule' => 'validDateValue',
+                    'allowEmpty' => true,
+                    'message' => 'Please enter a valid date of latest administration of the investigational product!'
+                ),
+                'dateBeforeAdministration' => array(
+                    'rule' => 'dateBeforeAdministration',
+                    'allowEmpty' => true,
+                  'message' => 'The date of the latest administration of the investigational product must be after the date
+      of enrollment into the study and date of initial administration!'
+               ),
+                'dateAfterBirthDate' => array(
+                   'rule' => 'dateAfterBirthDate',
+                   'allowEmpty' => true,
+                    'message' => 'The date of the latest administration of the investigational product must be after the date
+      of birth!'
+                )
             ),
-            'dateBeforeAdministration' => array(
-                'rule' => 'dateBeforeAdministration',
-                'message' => 'The date of initial administration of the investigational product must be after the date of enrollment into the study!'
+            'ip_not_given_narrative' => array(
+                'checkNarrativeRequired' => array(
+                    'rule' => 'checkNarrativeRequired',
+                    'message' => 'Please provide a narrative explaining why the IP was not given.'
+                )
             ),
-            'dateAfterBirthDate' => array(
-                'rule' => 'dateAfterBirthDate',
-                'message' => 'The date of initial administration of the investigational product must be after the date of birth!'
-            )
-        ),
-        'latest_date' => array(
-            'notEmpty' => array(
-                'rule' => 'notEmpty',
-                'required' => true,
-                'message' => 'Please enter the date of latest administration of the investigational product!'
-            ),
-            'validDateValue' => array(
-                'rule' => 'validDateValue',
-                'message' => 'Please enter a valid date of latest administration of the investigational product!'
-            ),
-            'dateBeforeAdministration' => array(
-                'rule' => 'dateBeforeAdministration',
-                'message' => 'The date of the latest administration of the investigational product must be after the date of enrollment into the study and date of initial administration!'
-            ),
-            'dateAfterBirthDate' => array(
-                'rule' => 'dateAfterBirthDate',
-                'message' => 'The date of the latest administration of the investigational product must be after the date of birth!'
-            )
-        ),
+
         'reaction_onset' => array(
             'notEmpty' => array(
                 'rule' => 'notEmpty',
@@ -474,6 +489,21 @@ class Sae extends AppModel {
     }
 
     public function beforeSave() {
+
+ if (!empty($this->data['Sae']['ip_not_given'])) {
+            
+                 $this->data['Sae']['administration_date'] = null;
+                 $this->data['Sae']['latest_date'] = null;
+             } else {
+        
+                 $this->data['Sae']['ip_not_given_narrative'] = null;
+                $this->data['Sae']['ip_not_given'] = 0;
+                
+                if (empty($this->data['Sae']['latest_date'])) {
+                     $this->data['Sae']['latest_date'] = null;
+                }
+            }
+
         if (!empty($this->data['Sae']['date_of_birth'])) {
             $this->data['Sae']['date_of_birth'] = $this->dateFormatBeforeSave($this->data['Sae']['date_of_birth']);
         }
@@ -658,4 +688,29 @@ class Sae extends AppModel {
 
         return strtotime($value);
     }
+
+         public function checkInitialRequired($check) {
+             if (!empty($this->data['Sae']['ip_not_given'])) {
+                 return true; 
+             }
+             $value = reset($check);
+             return !empty($value); 
+         }
+    
+        public function checkLatestDependency($check) {
+            $latestDate = reset($check);
+            
+            if (!empty($latestDate) && empty($this->data['Sae']['administration_date'])) {
+                return false;
+            }
+            return true;
+        }
+
+        public function checkNarrativeRequired($check) {
+            if (!empty($this->data['Sae']['ip_not_given'])) {
+                $value = reset($check);
+                return !empty($value); 
+            }
+            return true;
+        }
 }

--- a/app/View/Elements/application/sae_edit.ctp
+++ b/app/View/Elements/application/sae_edit.ctp
@@ -31,6 +31,7 @@
         <div class="span6">
         <?php
             echo $this->Form->input('id');
+              echo $this->Form->input('form_type', array('type' => 'hidden'));
             echo $this->Form->input('application_id', array('label' => array('class' => 'control-label required', 'text' => 'Protocol <span class="sterix">*</span>')));
         ?>
         </div>
@@ -46,12 +47,66 @@
                 echo $this->Form->input('enrollment_date', array('type' => 'text', 'class' => 'datepickers',
                     'label' => array('class' => 'control-label required', 'text' => 'Date of enrollment into the study </small> <span class="sterix">*</span>')
                 ));
-                echo $this->Form->input('administration_date', array('type' => 'text', 'class' => 'datepickers',
-                    'label' => array('class' => 'control-label required', 'text' => 'Date of initial administration of investigational product </small> <span class="sterix">*</span>')
-                ));
-                echo $this->Form->input('latest_date', array('type' => 'text', 'class' => 'datepickers',
-                    'label' => array('class' => 'control-label required', 'text' => 'Date of the latest administration of the investigational product </small> <span class="sterix">*</span>')
-                ));
+                ?>
+                  <div id="ip-dates-container">
+      <?php
+         echo $this->Form->input('administration_date', array(
+           'type' => 'text', 
+             'class' => 'datepickers ip-date-field',
+            'label' => array('class' => 'control-label', 'text' => 'Date of initial administration of investigational product
+      <span class="sterix" id="initial-sterix">*</span>')
+        ));
+        
+       echo $this->Form->input('latest_date', array(
+            'type' => 'text', 
+            'class' => 'datepickers ip-date-field',
+            'label' => array('class' => 'control-label', 'text' => 'Date of the latest administration of the investigational
+      product')
+        ));
+        ?>
+    </div>
+   
+    <?php
+    echo $this->Form->input('ip_not_given', array(
+        'type' => 'checkbox',
+        'id' => 'ip-not-given-checkbox',
+        'label' => array('class' => 'control-label', 'text' => 'IP was not given to the participant')
+    ));
+   
+ 
+    echo '<div id="ip-narrative-container" style="display: none;">';
+    echo $this->Form->input('ip_not_given_narrative', array(
+        'type' => 'textarea',
+        'id' => 'ip-not-given-narrative',
+        'label' => array('class' => 'control-label required', 'text' => 'Reason IP was not given <span
+      class="sterix">*</span>')
+    ));
+    echo '</div>';
+    ?>
+   
+    <script type="text/javascript">
+    $(document).ready(function() {
+        function toggleIpFields() {
+           if ($('#ip-not-given-checkbox').is(':checked')) {
+               $('#ip-narrative-container').slideDown();
+                $('.ip-date-field').val('').prop('disabled', true);
+                $('#initial-sterix').hide();
+            } else {
+                $('#ip-narrative-container').slideUp();
+                $('#ip-not-given-narrative').val('');
+                $('.ip-date-field').prop('disabled', false);
+                $('#initial-sterix').show();
+            }
+        }
+
+        toggleIpFields();
+   
+        $('#ip-not-given-checkbox').change(function() {
+            toggleIpFields();
+        });
+    });
+    </script>
+    <?php
                 echo $this->Form->input('reaction_onset', array('type' => 'text', 'class' => 'datepickers',
                     'label' => array('class' => 'control-label required', 'text' => 'Reaction Onset <span class="sterix">*</span>')
                 ));


### PR DESCRIPTION
This PR updates the Investigational Product (IP) administration section to support scenarios where the IP was not administered to a participant.

**What Changed**
Added a Narrative/Reason IP was not given textarea field.
Updated validation rules to allow a narrative when no administration dates are provided.
Removed the required indicator (*) from the Date of Latest Administration field since it is conditionally optional.

Implemented conditional field behavior:
When a narrative is entered, the Initial and Latest  Administration Date fields are disabled.
When an administration date is entered, the narrative field is disabled.
Added validation to prevent entry of a Latest Administration Date without an Initial Administration Date.

Updated form logic to ensure either:
Valid administration date information is provided ,or
A narrative explaining why the IP was not administered is provided.

**Why Was This Needed?**
The requirement specifies that users must be able to document cases where the Investigational Product was not administered to a participant. Previously, the form only supported administration dates and did not provide a mechanism to record such scenarios.

**Testing Performed**
**Manual Testing**
Verified that users can enter a narrative when the IP was not administered.
Verified that administration date fields are disabled when a narrative is entered.
Verified that the narrative field is disabled when administration dates are entered.
Verified that an Initial Administration Date can be entered without a Latest Administration Date.
Verified that a Latest Administration Date cannot be entered without an Initial Administration Date.
Verified that validation messages are displayed correctly.

**Screenshots**
**Before**
<img width="1331" height="912" alt="Screenshot From 2026-06-17 10-44-40" src="https://github.com/user-attachments/assets/6135e056-5a59-4eba-ac21-508993f0da61" />

**After**
<img width="1179" height="816" alt="Screenshot From 2026-06-17 10-36-35" src="https://github.com/user-attachments/assets/9e73f5a4-c032-47a7-82fe-9a522f1e375e" />

